### PR TITLE
Fix champ recherche de type select

### DIFF
--- a/includes/class/class.list.tbs.php
+++ b/includes/class/class.list.tbs.php
@@ -170,7 +170,7 @@ class TListviewTBS {
 		}
 	}
 	
-	private function addSqlFromOther(&$TSQLMore, &$value, $TParam, $sKey, $sBindKey)
+	private function addSqlFromOther(&$TSQLMore, &$value, &$TParam, $sKey, $sBindKey, $key)
 	{
 		if(isset($this->TBind[$sBindKey]))
 		{
@@ -194,9 +194,27 @@ class TListviewTBS {
 		{
 			$value = $this->getSearchValue($value);
 			
-			if(strpos($value,'%')===false) $value = '%'.$value.'%';
+			if(isset($TParam['operator'][$key]))
+			{
+				if($TParam['operator'][$key] == '<' || $TParam['operator'][$key] == '>' || $TParam['operator'][$key]=='=')
+				{
+					$TSQLMore[] = $sKey . ' ' . $TParam['operator'][$key] . ' "' . $value . '"';
+				}
+				elseif ($TParam['operator'][$key]=='IN')
+				{
+					$TSQLMore[] = $sKey . ' ' . $TParam['operator'][$key] . ' (' . $value . ')';
+				}
+				else
+				{
+					$TSQLMore[]=$sKey." LIKE '".addslashes($value)."'" ;
+				}
+			}
+			else
+			{
+				if(strpos($value,'%')===false) $value = '%'.$value.'%';
+				$TSQLMore[]=$sKey." LIKE '".addslashes($value)."'" ;
+			}
 			
-			$TSQLMore[]=$sKey." LIKE '".addslashes($value)."'" ;
 		}
 	}
 
@@ -261,7 +279,7 @@ class TListviewTBS {
 						}
 						else
 						{
-							$this->addSqlFromOther($TSQLMore, $value, $TParam, $sKey, $sBindKey);
+							$this->addSqlFromOther($TSQLMore, $value, $TParam, $sKey, $sBindKey, $key);
 						}
 					}
 				}


### PR DESCRIPTION
Cas pratique :
Champ de recherche de type select sur des catégorie
Si je filtre sur la catégorie id 3
La requête fait un test : LIKE "%3%"

ça me ressort une liste des produits qui sont dans la catégorie 13, 33, 1023 ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_abricot/22)
<!-- Reviewable:end -->
