### PR TITLE
FIX: filtres de colonnes mal appliqués quand plusieurs listes TBS sur une même page

### DIFF
--- a/includes/class/class.list.tbs.php
+++ b/includes/class/class.list.tbs.php
@@ -959,7 +959,7 @@ class TListviewTBS {
 		
 		global $user;
 		
-		$contextpage=md5($_SERVER['PHP_SELF']);
+		$contextpage=md5($_SERVER['PHP_SELF']).'_'.$this->id;
 		if((float)DOL_VERSION>=4.0 && empty($TParam['no-select'])) {
 			
 			dol_include_once('/core/class/html.form.class.php');


### PR DESCRIPTION
Les paramètres d'affichage des colonnes étaient stockés avec un identifiant basé sur l'URL de la page, donc quand une page contient plusieurs listes TBS, ça va taper dans la même conf et ça merde.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_abricot/37)
<!-- Reviewable:end -->
