### PR TITLE
FIX: can't redefine or call clearChildren()

### DIFF
--- a/includes/class/class.objet_std.php
+++ b/includes/class/class.objet_std.php
@@ -728,7 +728,7 @@ function _no_save_vars($lst_chp) {
 		return $this->save($db);
 	}
 	
-	private function clearChildren()
+	protected function clearChildren()
 	{
 		if (!empty($this->TChildObjetStd))
 		{


### PR DESCRIPTION
Pour cloner un objet standard, TObjetStd::cloneObject() appelle ::clearChildren(), qui est private. Donc on ne peut overrider ni ::cloneObject() ni ::clearChildren() si besoin de comportements spécifiques lors du clonage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_abricot/43)
<!-- Reviewable:end -->
