### PR TITLE
FIX: ListView(TBS): valider le filtrage avec Entrée pouvait ràz les filtres

### DIFF
--- a/includes/class/class.list.tbs.php
+++ b/includes/class/class.list.tbs.php
@@ -441,7 +441,7 @@ class TListviewTBS {
 		
 		$search_button = ' <div class="nowrap">';
 		$search_button.= '<a href="#" onclick="TListTBS_submitSearch(this);" class="list-search-link">'.$TParam['liste']['picto_search'].'</a>';
-		$search_button.= '&nbsp;<a href="#" onclick="TListTBS_submitSearch(this, true);" class="list-search-link">'.$TParam['liste']['picto_searchclear'].'</a>';
+		$search_button.= '&nbsp;<a href="#" onclick="TListTBS_submitSearch(this, true);" class="list-reset-link">'.$TParam['liste']['picto_searchclear'].'</a>';
 		$search_button.= '</div>';
 		
 		/* TODO remove => fait redondance, un bouton pour lancer la recherche est déjà présent

--- a/includes/class/class.listview.php
+++ b/includes/class/class.listview.php
@@ -393,7 +393,7 @@ class Listview
 		
 		$search_button = '<div class="nowrap">';
 		$search_button.= '<a href="#" onclick="Listview_submitSearch(this);" class="list-search-link">'.img_search().'</a>';
-		$search_button.= '&nbsp;<a href="#" onclick="Listview_clearSearch(this);" class="list-search-link">'.img_searchclear().'</a>';
+		$search_button.= '&nbsp;<a href="#" onclick="Listview_clearSearch(this);" class="list-reset-link">'.img_searchclear().'</a>';
 		$search_button.= '</div>';
 		
 		if($nb_search_in_bar>0)


### PR DESCRIPTION
L'appel qui est fait dans `/includes/js/list.tbs.js` à la pression de la touche entrée est :

`$('#'+id_list+' .list-search-link').click();`

Or, le lien pour remettre les filtres à zéro avait aussi la classe `list-search-link` => clic provoqué sur les deux => arbitrairement, ça faisait pas ce qu'il faut.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_abricot/55)
<!-- Reviewable:end -->
