### PR TITLE
use correct DB

### DIFF
--- a/includes/class/class.objet_std_dolibarr.php
+++ b/includes/class/class.objet_std_dolibarr.php
@@ -1,8 +1,20 @@
 <?php
 
 class TObjetStdDolibarr extends TObjetStd {
-	
-	/**
+
+    private $db;
+
+    /**
+     * TObjetStdDolibarr constructor.
+     *
+     * @param $db
+     */
+    public function __construct($db = null)
+    {
+        $this->db = $db;
+    }
+
+    /**
 	 * 
 	 * @param unknown $id
 	 * @return boolean
@@ -162,9 +174,14 @@ class TObjetStdDolibarr extends TObjetStd {
 		}
 	}
 	function get_newid(&$db){
+
+	    if(!isset($this->db)){
+	        $this->db = $db;
+        }
+
 		$sql="SELECT max(".OBJETSTD_MASTERKEY.") as 'maxi' FROM ".$this->get_table();
-		$res = $db->query($sql);
-		$object = $db->fetch_object($res);
+		$res = $this->db->query($sql);
+		$object = $this->db->fetch_object($res);
 		$this->{OBJETSTD_MASTERKEY} = (double)$object->maxi + 1;
 	}
 }

--- a/includes/class/class.objet_std_dolibarr.php
+++ b/includes/class/class.objet_std_dolibarr.php
@@ -163,8 +163,8 @@ class TObjetStdDolibarr extends TObjetStd {
 	}
 	function get_newid(&$db){
 		$sql="SELECT max(".OBJETSTD_MASTERKEY.") as 'maxi' FROM ".$this->get_table();
-		$res = $this->db->query($sql);
-		$object = $this->db->fetch_object($res);
+		$res = $db->query($sql);
+		$object = $db->fetch_object($res);
 		$this->{OBJETSTD_MASTERKEY} = (double)$object->maxi + 1;
 	}
 }


### PR DESCRIPTION
Hello,

I know this is your core library but the classes given by @atm-ph in #66 doesn't work properly. If you look the save function, the DB is never set. So now I use the one from the parameter if there is no one configured.

I also override the constructor to be able to set the db wrapper from the constructor.

I made that code backward compatible.

Kind regards
L.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_abricot/68)
<!-- Reviewable:end -->
