### PR TITLE
FIX: pagination in Abricot’s ListView

### DIFF
--- a/includes/class/class.listview.php
+++ b/includes/class/class.listview.php
@@ -746,7 +746,7 @@ class Listview
 		}
 		else
         {
-			$line_number = 0;
+			$line_number = $TParam['limit']['page'] * $TParam['limit']['nbLine'];
 			foreach($TField as $fields)
 			{
 				if($this->in_view($TParam, $line_number))


### PR DESCRIPTION
$line_number, which I understand to be the number the current line would have if there were no pagination, was set to 0, causing in_view() to always return false except on the first page.