### PR TITLE
FIX: Listview/TListviewTBS: ne pas recompter le nombre de lignes à chaque itération (tk 10181)

### DIFF
--- a/includes/class/class.list.tbs.php
+++ b/includes/class/class.list.tbs.php
@@ -33,6 +33,7 @@ class TListviewTBS {
 
 		$this->sql = '';
 
+		$this->line_counter = 0;
 	}
 	private function init(&$TParam) {
 
@@ -1084,7 +1085,7 @@ class TListviewTBS {
 
 	}
 
-	private function in_view(&$TParam, $line_number) {
+	private function in_view(&$TParam) {
 		global $conf;
 //		var_dump($_REQUEST['get-all-for-export']);
 		if(!empty($_REQUEST['get-all-for-export'])) return true; // doit être dans la vue
@@ -1095,7 +1096,7 @@ class TListviewTBS {
 		$start = ($page_number-1) * $line_per_page;
 		$end = ($page_number* $line_per_page) -1;
 
-		if($line_number>=$start && $line_number<=$end) return true;
+		if($this->line_counter >= $start && $this->line_counter <= $end) return true;
 		else return false;
 	}
 
@@ -1103,9 +1104,7 @@ class TListviewTBS {
 
 			global $conf;
 
-			$line_number = count($TChamps);
-
-			if($this->in_view($TParam,$line_number)) {
+			if($this->in_view($TParam)) {
 
 				$row=array(); $trans = array();
 				foreach($currentLine as $field=>$value) {
@@ -1209,7 +1208,9 @@ class TListviewTBS {
 				}
 			}
 			}
+
 			$TChamps[] = $row;
+			$this->line_counter++;
 	}
 
 	private function getBind(&$TParam) {

--- a/includes/class/class.listview.php
+++ b/includes/class/class.listview.php
@@ -41,6 +41,7 @@ class Listview
 		$this->form = null;
 		$this->totalRowToShow=0;
 		$this->totalRow=0;
+		$this->lineCounter=0;
 		
 		$this->TField=array();
 		
@@ -1004,8 +1005,8 @@ class Listview
         global $conf;
 
 		// TODO problème d'affichage on passe jamais dans le if in_view
-        $line_number = $TParam['limit']['page'] * $TParam['limit']['nbLine'] + count($TFieldParsed);
-        if($this->in_view($TParam,$line_number))
+        $line_number = $TParam['limit']['page'] * $TParam['limit']['nbLine'] + $this->lineCounter;
+        if($this->in_view($TParam, $line_number))
         {
 			$this->totalRowToShow++;
             $row=array(); 
@@ -1117,6 +1118,7 @@ class Listview
         }
 
         $TFieldParsed[] = $row;
+        $this->lineCounter++;
 	}
 
     /**


### PR DESCRIPTION
Chez le client en question, l'affichage de la liste passe de près de 2 minutes à instantané...

Le correctif est un peu différent entre le `Listview` et le `TListviewTBS` du fait des quelques différences entre les deux (la méthode `in_view()` n'est utilisée qu'une fois dans le `TListviewTBS` par exemple).