### PR TITLE
FIX: unescaped quotes caused syntax error in the eval() statement

### DIFF
--- a/includes/class/class.list.tbs.php
+++ b/includes/class/class.list.tbs.php
@@ -1136,7 +1136,10 @@ class TListviewTBS {
 						$row[$field]=$value;
 
 						if(isset($TParam['eval'][$field]) && in_array($field,array_keys($row))) {
-							$strToEval = 'return '.strtr( $TParam['eval'][$field] ,  array_merge( $trans, array('@val@'=>$row[$field])  )).';';
+							$strToEval = 'return '.strtr(
+								$TParam['eval'][$field],
+								array_merge($trans, array('@val@'=>addslashes($row[$field])))
+								).';';
 							$row[$field] = eval($strToEval);
 						}
 


### PR DESCRIPTION
Example: in the TListviewTBS, if the configuration array has
```php
$configArray['eval]['myfield'] = "strtoupper('@val@')";
```
And the value read from the database is `"en fin d'année"`, the eval string will be syntactically incorrect:
```php
return strtoupper('en fin d'année');
```