### PR TITLE
FIX: currently setup_print_on_off prints an unused form

### DIFF
--- a/includes/lib/admin.lib.php
+++ b/includes/lib/admin.lib.php
@@ -68,11 +68,7 @@ function setup_print_on_off($confkey, $title = false, $desc ='', $help = false, 
     print '</td>';
     print '<td align="center" width="20">&nbsp;</td>';
     print '<td align="center" width="'.$width.'">';
-    print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
-    print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
-    print '<input type="hidden" name="action" value="set_'.$confkey.'">';
     print ajax_constantonoff($confkey);
-    print '</form>';
     print '</td></tr>';
 }
 


### PR DESCRIPTION
Since in HTML `<form>` nesting is not valid, it causes the hidden inputs to be attached to the parent form if `setup_print_on_off()` is called inside an existing form.

In one instance (on the "caisse" module), the 'action' hidden input overrode the parent form’s 'action' and caused the whole admin page to be paralyzed (saving any value other than the one using `setup_print_on_off` was impossible).

Since the `<form>` printed by the function is not used at all (even when javascript is disabled), I think it is safe to remove it.