### PR TITLE
FIX : Missing help tweak on setup_print_input_form_part lib

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ ___
 
 ## [Unreleased]
 
+- FIX : Missing help tweak on setup_print_input_form_part lib *26/03/2021* - 3.2.2
 - FIX : Listview context detection for columns [2021-01-04]
 - NEW : Listview tooltip param  [2020-12-15]
   Allow usage of tooltip key in listview params to add tooltips for cols

--- a/core/modules/modAbricot.class.php
+++ b/core/modules/modAbricot.class.php
@@ -61,7 +61,7 @@ class modAbricot extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Collection of specific ATM functions and classes";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.2.1';
+        $this->version = '3.2.2';
         $this->editor_name = 'ATM-Consulting';
         $this->editor_url = 'https://www.atm-consulting.fr';
         // Key used in llx_const table to save module status enabled/disabled

--- a/includes/lib/admin.lib.php
+++ b/includes/lib/admin.lib.php
@@ -185,6 +185,10 @@ function setup_print_input_form_part($confkey, $title = false, $desc ='', $metas
     global $var, $bc, $langs, $conf, $db;
     $var=!$var;
 
+	if(empty($help) && !empty($langs->tab_translate[$confkey . '_HELP'])){
+		$help = $confkey . '_HELP';
+	}
+
     $form=new Form($db);
 
     $defaultMetas = array(


### PR DESCRIPTION
Les tooltips d'aide automatique sur detection de la traduction finissant par _HELP n’étaient pas prisent en comptes