### PR TITLE
Fix retro - retro compat fatal error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ ___
 
 ## RELEASE 3.5
 
+- FIX : Retro compat *18/11/2022* - 3.5.3
 - FIX : Fix divers warnings PHP8 *16/08/2022* - 3.5.2
 - FIX : Change editor name : ATM-Consulting -> ATM Consulting *3.5.1* - **09/08/2022**
 - NEW : Ajout d'un filtre sur listview permettant au multiselect de trier avec plusieurs tags *27/07/2022* - 3.5.0

--- a/backport/v12/core/lib/fonctions.lib.php
+++ b/backport/v12/core/lib/fonctions.lib.php
@@ -1,16 +1,23 @@
 <?php
 
+
 if ((float) DOL_VERSION < 12) {
 
-	/**
-	 * Return the value of token currently saved into session with name 'newtoken'.
-	 * This token must be send by any POST as it will be used by next page for comparison with value in session.
-	 *
-	 * @return  string
-	 */
-	function newToken()
-	{
-		return $_SESSION['newtoken'];
+	// Apparemment il y a un de (j'en un génie) qui s'est dit que le fait que newtoken n'existe pas en 9.0 est un bug pour la retro-compat de module builder
+	// du coup il a fait une PR pour ça : maintenant il faut savoir qu'en fonction de la 9.0 de Doli c'est pile ou face pour avoir la fonction sur les clients...
+	// Du génie je vous dis ! Grace à lui on peut gérer des problèmes que l'on n'aurait pas eus à la base...
+	if(!function_exists('newToken')){
+
+		/**
+		 * Return the value of token currently saved into session with name 'newtoken'.
+		 * This token must be send by any POST as it will be used by next page for comparison with value in session.
+		 *
+		 * @return  string
+		 */
+		function newToken()
+		{
+			return $_SESSION['newtoken'];
+		}
 	}
 
 }

--- a/backport/v12/core/lib/fonctions.lib.php
+++ b/backport/v12/core/lib/fonctions.lib.php
@@ -3,7 +3,7 @@
 
 if ((float) DOL_VERSION < 12) {
 
-	// Apparemment il y a un de (j'en un génie) qui s'est dit que le fait que newtoken n'existe pas en 9.0 est un bug pour la retro-compat de module builder
+	// Apparemment il y a un DEV (Genre un génie) qui s'est dit que le fait que newtoken n'existe pas en 9.0 est un bug pour la retro-compat de module builder
 	// du coup il a fait une PR pour ça : maintenant il faut savoir qu'en fonction de la 9.0 de Doli c'est pile ou face pour avoir la fonction sur les clients...
 	// Du génie je vous dis ! Grace à lui on peut gérer des problèmes que l'on n'aurait pas eus à la base...
 	if(!function_exists('newToken')){

--- a/core/modules/modAbricot.class.php
+++ b/core/modules/modAbricot.class.php
@@ -61,7 +61,7 @@ class modAbricot extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Collection of specific ATM functions and classes";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.5.2';
+        $this->version = '3.5.3';
         $this->editor_name = 'ATM Consulting';
         $this->editor_url = 'https://www.atm-consulting.fr';
         // Key used in llx_const table to save module status enabled/disabled


### PR DESCRIPTION
Apparemment il y a un DEV (Genre un génie) qui s'est dit que le fait que newtoken n'existe pas en 9.0 est un bug pour la retro-compat de module builder
du coup il a fait une PR pour ça : maintenant il faut savoir qu'en fonction de la 9.0 de Doli c'est pile ou face pour avoir la fonction sur les clients...
Du génie je vous dis ! Grace à lui on peut gérer des problèmes que l'on n'aurait pas eus à la base...