### PR TITLE
fix backtick missing arround database name

### DIFF
--- a/includes/class/class.seedobject.php
+++ b/includes/class/class.seedobject.php
@@ -1432,7 +1432,7 @@ class SeedObject extends SeedObjectDolibarr
 
 		if(!empty($this->isextrafieldmanaged))
         {
-            $resql = $this->db->query("SHOW TABLES FROM " . $dolibarr_main_db_name . " LIKE '" . MAIN_DB_PREFIX . $this->table_element . "_extrafields'");
+            $resql = $this->db->query("SHOW TABLES FROM `" . $dolibarr_main_db_name . "` LIKE '" . MAIN_DB_PREFIX . $this->table_element . "_extrafields'");
             if($resql === false) {
                 var_dump($this->db);exit;
             }


### PR DESCRIPTION
Here is a quick fix for that problem:

```
sql=SHOW TABLES FROM doli-15 LIKE 'llx_paymentschedule_extrafields'
DoliDBMysqli::query SQL Error message: DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '-15 LIKE 'llx_paymentschedule_extrafields'' at line 1
```
