### PR TITLE
FIX auto: add missing licensing information

### DIFF
--- a/backport/v12/core/lib/fonctions.lib.php
+++ b/backport/v12/core/lib/fonctions.lib.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 
 if ((float) DOL_VERSION < 12) {

--- a/downlist.php
+++ b/downlist.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 	$s_name = $_POST['session_name'] or die('Pas de session trouvée');
 	session_name($s_name);

--- a/script/change-datetime-default-to-null.php
+++ b/script/change-datetime-default-to-null.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 if(is_file('../master.inc.php')) include '../master.inc.php';
 elseif(is_file('../../../master.inc.php')) include '../../../master.inc.php';
 elseif(is_file('../../../../master.inc.php')) include '../../../../master.inc.php';

--- a/script/change-text-varchar-encoding-to-conf-value.php
+++ b/script/change-text-varchar-encoding-to-conf-value.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 if(is_file('../master.inc.php')) include '../master.inc.php';
 elseif(is_file('../../../master.inc.php')) include '../../../master.inc.php';

--- a/script/common_script.lib.php
+++ b/script/common_script.lib.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 /**
  * COMMON ABRICOT SCRIPT TOOL

--- a/script/data-migration-ticketSup.php
+++ b/script/data-migration-ticketSup.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 /**
  * NOTE IMPORTANTE : Ce script ne rappatrie pas, dans llx_actioncomm, les messages présents dans la table llx_ticket_msg

--- a/script/migration_ticketmsg_to_actioncomm.php
+++ b/script/migration_ticketmsg_to_actioncomm.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 if (is_file('../master.inc.php')) include '../master.inc.php';
 elseif (is_file('../../../master.inc.php')) include '../../../master.inc.php';

--- a/script/set-atm-default-config.php
+++ b/script/set-atm-default-config.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 if(is_file('../master.inc.php')) include '../master.inc.php';
 elseif(is_file('../../../master.inc.php')) include '../../../master.inc.php';
 elseif(is_file('../../../../master.inc.php')) include '../../../../master.inc.php';

--- a/tpl/extrafields_setup.tpl.php
+++ b/tpl/extrafields_setup.tpl.php
@@ -1,4 +1,9 @@
 <?php
+/**
+* SPDX-License-Identifier: GPL-3.0-or-later
+* This file is part of Dolibarr module Abricot
+*/
+
 
 // EXEMPLE OF USAGE IN YOUR admin/mymodule_extrafields.php
 ///*


### PR DESCRIPTION
Je ne pense pas que ça nécessite d'incrémenter le numéro de module ou de changelog, dites-moi si vous n'êtes pas d'accord. J'ai même hésité à pousser directement dans la main, mais je me suis retenu.

#### Important
Je n'ai pas touché aux fichiers présents dans le répertoire `includes`, mais j'ai vérifié que toutes les libs étaient bien compatibles GPL :
- datatables => licence MIT, compatible GPL
- tbs => LGPL, compatible GPL
- CKEditor => GPL
- jsCalendar => MIT
- timepicker => MIT
- iCalcreator => LGPL
- iCalReader => MIT
- JSON.php => 2-clause BSD (=FreeBSD), compatible GPL
- Wkhtmltopdf.php => Modified BSD, compatible GPL

Donc c'est OK :)