### PR TITLE
FIX 3.8.4 : TBS render: remove trailing semicolon before concatenating more SQL to the query

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ ___
 
 
 ## RELEASE 3.6
+- FIX : TBS render: remove trailing semicolon before concatenating more SQL to the query - *02/05/2024* - 3.8.4
 - FIX : Warning php 8.2  warning undefined array key visible - *13/03/2024* - 3.8.3
 - FIX : Warning php 8.2  warning undefined array key visible - *14/12/2023* - 3.8.2
 - FIX : Warning php 8.2 - *11/12/2023* - 3.8.1

--- a/core/modules/modAbricot.class.php
+++ b/core/modules/modAbricot.class.php
@@ -61,7 +61,7 @@ class modAbricot extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Collection of specific ATM functions and classes";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '3.8.3';
+        $this->version = '3.8.4';
         $this->editor_name = 'ATM Consulting';
         $this->editor_url = 'https://www.atm-consulting.fr';
         // Key used in llx_const table to save module status enabled/disabled

--- a/includes/class/class.list.tbs.php
+++ b/includes/class/class.list.tbs.php
@@ -1,4 +1,4 @@
-<?php
+    <?php
 /*
 
  Copyright (C) 2013-2015 ATM Consulting <support@atm-consulting.fr>
@@ -338,6 +338,9 @@ class TListviewTBS {
 
 		if(!empty($TBind)) $this->TBind = $TBind;
 
+		// remove any trailing semicolon before appending anything to the query
+		$sql = preg_replace('/;\s*$/', '', $sql);
+
 		$sql = $this->search($sql,$TParam);
 		$sql = $this->order_by($sql, $TParam);
 
@@ -368,6 +371,9 @@ class TListviewTBS {
 		$TChamps=array();
 
 		$this->init($TParam);
+
+		// remove any trailing semicolon before appending anything to the query
+		$sql = preg_replace('/;\s*$/', '', $sql);
 
 		$sql = $this->search($sql,$TParam);
 		$sql = $this->order_by($sql, $TParam);


### PR DESCRIPTION
Si on passe au ListViewTBS d'Abricot une requête qui se termine par un `;`, on a des problèmes car le ListView ajoute du SQL à la requête (la PHPDoc ne précise pas ce qui est attendu ou ce qui va se passer puisqu'il n'y a pas de PHPDoc :grimacing:).

Honnêtement, je suis même pas certain que cette PR soit la bonne solution : il vaudrait mieux mettre de la doc et indiquer ce qui est admissible ou pas dans `$sql` (et les autres paramètres), mais ça prendrait beaucoup plus de temps et d'analyse.